### PR TITLE
[updated] minimum sdk version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "28.0.3"
-        minSdkVersion = 16
+        minSdkVersion = 21
         compileSdkVersion = 28
         targetSdkVersion = 28
     }


### PR DESCRIPTION
Because we are using **com.facebook.react:react-native:0.64.0** it creates a _**AndroidManifest.xml**_ merge conflict and hence the merger fails; resulting in **BUILD FAILED**.

We have option to either downgrade the faebook dependency or increase the minsdkversion, i chose to increase the minsdk version because downgrading the facebook dependency may have some deprecated APIs and then again some other issue will arise.

Thanks!